### PR TITLE
thingdb2 support

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -80,9 +80,7 @@ class IRC(irc.client.SimpleIRCClient):
         self.config_file = config_file
         self.conf_mtime = None
         self.connected = False
-        if not os.path.exists("state.db"):
-            thingdb.save({}, "state.db")
-        self.state = thingdb.start("state.db")
+        self.state = thingdb.thing("state.db")
         if "server" not in self.state:
             self.state["server"] = {}
         if "channels" not in self.state:
@@ -196,7 +194,7 @@ class IRC(irc.client.SimpleIRCClient):
         self.config["throttle"] = self.throttle
         self.config["burst"] = self.burst
         config.save(self.config_file, self.config)
-        thingdb.save(self.state, "state.db")
+        self.state.save()
         log.info("Config saved to file.")
 
     def set_rate_limit(self, frequency, skip_for=0):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 -e git+https://github.com/devzero-xyz/irc.git#egg=irc
--e git+https://github.com/devzero-xyz/thing.git@1#egg=thingdb
 requests
+thingdb


### PR DESCRIPTION
Adds support for thingdb2. Only issue is self.state cannot be accessed as-if it was a dict itself (e.g json.dumps(self.state) ). Only things like self.state['blah'] etc will work.
